### PR TITLE
feat: skip indexclonestep from clone script

### DIFF
--- a/src/commands/hub/clone.ts
+++ b/src/commands/hub/clone.ts
@@ -10,7 +10,7 @@ import { ContentCloneStep } from './steps/content-clone-step';
 import { SchemaCloneStep } from './steps/schema-clone-step';
 import { SettingsCloneStep } from './steps/settings-clone-step';
 import { TypeCloneStep } from './steps/type-clone-step';
-import { IndexCloneStep } from './steps/index-clone-step';
+// import { IndexCloneStep } from './steps/index-clone-step';
 import { CloneHubState } from './model/clone-hub-state';
 import { LogErrorLevel } from '../../common/archive/archive-log';
 import { ExtensionCloneStep } from './steps/extension-clone-step';

--- a/src/commands/hub/clone.ts
+++ b/src/commands/hub/clone.ts
@@ -10,7 +10,7 @@ import { ContentCloneStep } from './steps/content-clone-step';
 import { SchemaCloneStep } from './steps/schema-clone-step';
 import { SettingsCloneStep } from './steps/settings-clone-step';
 import { TypeCloneStep } from './steps/type-clone-step';
-import { IndexCloneStep } from './steps/index-clone-step';
+// import { IndexCloneStep } from './steps/index-clone-step';
 import { CloneHubState } from './model/clone-hub-state';
 import { LogErrorLevel } from '../../common/archive/archive-log';
 import { ExtensionCloneStep } from './steps/extension-clone-step';
@@ -46,8 +46,8 @@ export const steps = [
   new ExtensionCloneStep(),
   new SchemaCloneStep(),
   new TypeCloneStep(),
-  new ContentCloneStep(),
-  new IndexCloneStep(),
+  // new IndexCloneStep(),
+  new ContentCloneStep()
 ];
 
 export const builder = (yargs: Argv): void => {

--- a/src/commands/hub/clone.ts
+++ b/src/commands/hub/clone.ts
@@ -10,7 +10,7 @@ import { ContentCloneStep } from './steps/content-clone-step';
 import { SchemaCloneStep } from './steps/schema-clone-step';
 import { SettingsCloneStep } from './steps/settings-clone-step';
 import { TypeCloneStep } from './steps/type-clone-step';
-// import { IndexCloneStep } from './steps/index-clone-step';
+import { IndexCloneStep } from './steps/index-clone-step';
 import { CloneHubState } from './model/clone-hub-state';
 import { LogErrorLevel } from '../../common/archive/archive-log';
 import { ExtensionCloneStep } from './steps/extension-clone-step';
@@ -46,8 +46,8 @@ export const steps = [
   new ExtensionCloneStep(),
   new SchemaCloneStep(),
   new TypeCloneStep(),
-  // new IndexCloneStep(), # Algolia error (o.O) Ampleinece is workiung on a fix - until then we will skip this step
-  new ContentCloneStep()
+  new ContentCloneStep(),
+  new IndexCloneStep(),
 ];
 
 export const builder = (yargs: Argv): void => {

--- a/src/commands/hub/clone.ts
+++ b/src/commands/hub/clone.ts
@@ -46,7 +46,7 @@ export const steps = [
   new ExtensionCloneStep(),
   new SchemaCloneStep(),
   new TypeCloneStep(),
-  new IndexCloneStep(),
+  // new IndexCloneStep(), # Algolia error (o.O) Ampleinece is workiung on a fix - until then we will skip this step
   new ContentCloneStep()
 ];
 


### PR DESCRIPTION
As we are getting "Algolia" Errors when running the clone script (and as wer are not using Algolia anyway) we can safely dismiss this step when cloning Hubs.